### PR TITLE
Canceled cloning when user disconnects

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -17,6 +17,8 @@ server.listen(port, () => {
 });
 
 io.on('connection', socket => {
+    let provider = null;
+
     socket.on('fishmanRequest', request => {
         const options = {
             packageManager: request.pm,
@@ -34,7 +36,7 @@ io.on('connection', socket => {
             size: 0,
         };
 
-        fishmanWeb.cloneModule(options, fileSystem, finalDownload, (typeOfUpdate, content) => {
+        provider = fishmanWeb.cloneModule(options, fileSystem, finalDownload, (typeOfUpdate, content) => {
             switch (typeOfUpdate) {
                 case 'downloadProgress':
                     socket.emit(typeOfUpdate, content);
@@ -57,10 +59,10 @@ io.on('connection', socket => {
             }
         });
     });
-
-    //TODO
-    /*
+    
     socket.on('disconnect', () => {
+        if (provider) {
+            provider.cancel();
+        }
     });
-    */
 });

--- a/bin/server.js
+++ b/bin/server.js
@@ -32,6 +32,7 @@ io.on('connection', socket => {
             size: 0,
         };
 
+        // TODO move updates to event handler on provider
         provider = fishmanWeb.cloneModule(options, finalDownload, (typeOfUpdate, content) => {
             switch (typeOfUpdate) {
                 case 'downloadProgress':
@@ -55,7 +56,7 @@ io.on('connection', socket => {
             }
         });
     });
-    
+
     socket.on('disconnect', () => {
         console.log(`User Disconnected. Cancelling request.`);
         if (provider) {

--- a/bin/server.js
+++ b/bin/server.js
@@ -4,7 +4,6 @@ const express = require('express');
 const app = express();
 const server = require('http').Server(app);
 const io = require('socket.io')(server);
-const memoryFileSystem = require('memory-fs');
 const ss = require('socket.io-stream');
 const fishmanWeb = require('../lib');
 const path = require('path'); //used only for express to serve statics
@@ -26,17 +25,14 @@ io.on('connection', socket => {
             incDeps: request.incDeps,
             incDevDeps: request.incDevDeps,
             incTypes: request.incTypes,
-            basePath: '/',
         };
-
-        const fileSystem = new memoryFileSystem();
 
         let finalDownload = {
             stream: ss.createStream(),
             size: 0,
         };
 
-        provider = fishmanWeb.cloneModule(options, fileSystem, finalDownload, (typeOfUpdate, content) => {
+        provider = fishmanWeb.cloneModule(options, finalDownload, (typeOfUpdate, content) => {
             switch (typeOfUpdate) {
                 case 'downloadProgress':
                     socket.emit(typeOfUpdate, content);
@@ -61,6 +57,7 @@ io.on('connection', socket => {
     });
     
     socket.on('disconnect', () => {
+        console.log(`User Disconnected. Cancelling request.`);
         if (provider) {
             provider.cancel();
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,10 @@
 /**
  * Module dependencies
  */
-const Npm = require('./providers/npm'); //gg
+const Npm = require('./providers/npm');
 const async = require('async');
+
+const basePath = '/';
 
 /**
  * Download module and its dependencies from different package managers
@@ -13,7 +15,6 @@ const async = require('async');
  *		basePath: Local or in-memory repository directory
  *		incDeps: Should download module dependencies
  *		incDevDeps: Should download module dev dependencies
- * @param {Object} fileSystem: Either fs or fs-compatible Object
  * @param {Object} result:
  *      stream: (socket.io-stream).createStream() object
  *      size: Length of above stream
@@ -21,16 +22,14 @@ const async = require('async');
  */
 function cloneModule(
     { packageManager, incDeps, incDevDeps, incTypes, modules },
-    fileSystem,
     streamToWriteTo,
     cbUpdate
 ) {
     let provider = null;
-    const basePath = '/';
 
     switch (packageManager) {
         case 'npm':
-            provider = new Npm(fileSystem, incDeps, incDevDeps, incTypes, cbUpdate);
+            provider = new Npm(incDeps, incDevDeps, incTypes, cbUpdate);
             break;
         default:
             provider = null;
@@ -45,13 +44,13 @@ function cloneModule(
             modules,
             (module, cbFinish) => {
                 // If module name contains '/' char, replace it with '-'
-                const path = fileSystem.join(
+                const path = provider.fileSystem.join(
                     basePath,
                     `${module.name.replace('/', '-')}${module.ver ? `-${module.ver}` : ''}`
                 );
                 async.waterfall(
                     [
-                        callback => fileSystem.mkdir(path, err => callback(err)),
+                        callback => provider.fileSystem.mkdir(path, err => callback(err)),
                         callback => provider.cloneModule(module.name, module.ver, path, callback),
                     ],
                     err => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,12 +20,13 @@ const async = require('async');
  * @param {Function} cbUpdate Callback function (typeOfUpdate, content)
  */
 function cloneModule(
-    { packageManager, basePath, incDeps, incDevDeps, incTypes, modules },
+    { packageManager, incDeps, incDevDeps, incTypes, modules },
     fileSystem,
     streamToWriteTo,
     cbUpdate
 ) {
     let provider = null;
+    const basePath = '/';
 
     switch (packageManager) {
         case 'npm':
@@ -50,7 +51,7 @@ function cloneModule(
                 );
                 async.waterfall(
                     [
-                        callback => fileSystem.mkdir(path, err => callback(err)), // TODO make this be a part of the waterfall
+                        callback => fileSystem.mkdir(path, err => callback(err)),
                         callback => provider.cloneModule(module.name, module.ver, path, callback),
                     ],
                     err => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,11 +25,14 @@ function cloneModule(
     streamToWriteTo,
     cbUpdate
 ) {
-    let provider;
+    let provider = null;
 
     switch (packageManager) {
         case 'npm':
             provider = new Npm(fileSystem, incDeps, incDevDeps, incTypes, cbUpdate);
+            break;
+        default:
+            provider = null;
             break;
     }
 
@@ -72,14 +75,16 @@ function cloneModule(
                     cbUpdate('criticalError', { message: `something wrong happened!! ${err.toString()}` });
                 } else {
                     provider.getDownloadStreamFromBasePath(
-                        streamToWriteTo, 
-                        basePath, 
+                        streamToWriteTo,
+                        basePath,
                         err => cbUpdate('criticalError', { message: `something wrong happened!! ${err.toString()}` })
                     );
                 }
             }
         );
     }
+
+    return provider;
 }
 
 exports.cloneModule = cloneModule;

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -22,6 +22,8 @@ class Provider {
         this.fileSystem = fileSystem;
         this.incTypes = incTypes;
         this.cbUpdate = cbUpdate;
+
+        this._isCancelled = false;
     }
 
     // Abstract methods
@@ -174,6 +176,10 @@ class Provider {
      * @param {Function} callback Callback function (err)
      */
     cloneModule(module, ver, path, callback) {
+        if (this._isCancelled) {
+            return;
+        }
+
         const self = this;
         const escapedModule = module.replace('/', '%2f');
         async.waterfall(
@@ -290,6 +296,10 @@ class Provider {
             ],
             () => self.cbUpdate('finalDownloadToClient')
         );
+    }
+
+    cancel() {
+        this._isCancelled = true;
     }
 }
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -3,6 +3,7 @@
  */
 const async = require('async');
 const tar = require('tar-stream');
+const MemoryFileSystem = require('memory-fs');
 
 class Provider {
     /**
@@ -10,19 +11,18 @@ class Provider {
      * This is an abstract class that should not by instantiated directly.
      * @abstract
      * @class Provider Base class for package manager providers
-     * @param {Object} fileSystem Either fs or fs-compatible Object
      * @param {Boolean} incDeps Should download module dependencies
      * @param {Boolean} incDevDeps Should download module dev dependencies
      * @param {Boolean} incTypes Should download types module (like typescript module)
      * @param {Function} cbUpdate Callback function (typeOfUpdate, content)
      */
-    constructor(fileSystem, incDeps, incDevDeps, incTypes, cbUpdate) {
+    constructor(incDeps, incDevDeps, incTypes, cbUpdate) {
         this.incDeps = incDeps;
         this.incDevDeps = incDevDeps;
-        this.fileSystem = fileSystem;
         this.incTypes = incTypes;
         this.cbUpdate = cbUpdate;
 
+        this.fileSystem = new MemoryFileSystem();
         this._isCancelled = false;
     }
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -186,7 +186,7 @@ class Provider {
             [
                 callback => self.cloneSingleModule(escapedModule, ver, path, callback),
                 (ver, callback) => {
-                    if (self.incTypes) {
+                    if (self.incTypes && !this._isCancelled) {
                         self.getTypesModuleIfExist(escapedModule, ver, path, callback);
                     } else {
                         callback(null, ver);

--- a/lib/providers/npm.js
+++ b/lib/providers/npm.js
@@ -19,13 +19,12 @@ class NpmProvider extends Provider {
     /**
      * Create a new npm provider object
      * @class Npm Provider for npm modules
-     * @param {Object} fileSystem Either fs or fs-compatible Object
      * @param {Boolean} incDeps Should download module dependencies
      * @param {Boolean} incDevDeps Should download module dev dependencies
      * @param {Function} cbUpdate Callback function (typeOfUpdate, content)
      */
-    constructor(fileSystem, incDeps, incDevDeps, incTypes, cbUpdate) {
-        super(fileSystem, incDeps, incDevDeps, incTypes, cbUpdate);
+    constructor(incDeps, incDevDeps, incTypes, cbUpdate) {
+        super(incDeps, incDevDeps, incTypes, cbUpdate);
     }
 
     /**

--- a/lib/providers/npm.js
+++ b/lib/providers/npm.js
@@ -121,7 +121,6 @@ class NpmProvider extends Provider {
      */
     cloneSingleModule(module, ver, path, callback) {
         const self = this;
-        // var fullPath = this.fileSystem.join(path, module);
         let packageJson;
         async.waterfall(
             [


### PR DESCRIPTION
I implemented a listener for the disconnect event on socket. It now cancels the cloning process for the module.

On the way, I moved the initialization of the MemoryFileSystem object to the provider. Other modules access the file system through the provider. I simply thought that the file system is a part of the provider and accesses should be made though it. Let me know if you disagree.